### PR TITLE
feat: Add possibility of having global fields

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,12 +25,21 @@ Once you have setup your `type` field, you need to name your fields like the abo
 | block      | image     | picture |
 | block      | image     | alt     |
 
+> Also you can include `global` fields, that will be visible for any type
+
+| collection | type      | field   |
+|------------|-----------|---------|
+| block      | global	 | title   |
+| block      | global	 | slug	   |
+
 So the fields in the database should be like
 ```
 block_editorial_text
 block_editorial_intro
 block_image_picture
 block_image_alt
+block_global_title
+block_global_slug
 ```
 
 With that config, if you select the type `editorial` in the dropdown, only the `text` and `intro` fields will appear on the screen.

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ With that config, if you select the type `editorial` in the dropdown, only the `
 
 ### Import conditional-fields into the collection
 Once you have setup your fields, you can then just add the `conditional-fields` field so the javascript can do his job on the administration page.
+
 *NOTE*: you will have to name the field `conditional_interface`
 
 And that's it !

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ With that config, if you select the type `editorial` in the dropdown, only the `
 
 ### Import conditional-fields into the collection
 Once you have setup your fields, you can then just add the `conditional-fields` field so the javascript can do his job on the administration page.
-*NOTE*: you will have to name the field `conditional-fields`
+*NOTE*: you will have to name the field `conditional_interface`
 
 And that's it !
 

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ block_global_title
 block_global_slug
 ```
 
-With that config, if you select the type `editorial` in the dropdown, only the `text` and `intro` fields will appear on the screen.
+With that config, if you select the type `editorial` in the dropdown, only the `title`, `slug`, `text` and `intro` fields will appear on the screen.
 
 ### Import conditional-fields into the collection
 Once you have setup your fields, you can then just add the `conditional-fields` field so the javascript can do his job on the administration page.

--- a/src/input.vue
+++ b/src/input.vue
@@ -52,7 +52,7 @@
           let field = fieldsNode[i].dataset.field
           if (field !== 'status' &&
           field !== 'type' &&
-          field !== 'title' )
+          field.key.split("_")[1] !== 'global' )
           fieldsNode[i].style.display = 'none'
         }
       },

--- a/src/input.vue
+++ b/src/input.vue
@@ -9,7 +9,7 @@
     mixins: [mixin],
     mounted() {
       // Fetch block options
-      const { values, fields } = this._props
+      const { values } = this._props
       const fieldsNode = document.querySelectorAll('[data-field]');
       const conditionalInterface = document.querySelector('[data-field="conditional_interface"]');
       const typeField = document.querySelector('[data-field=type]');
@@ -47,12 +47,12 @@
         }
       },
       hideAll(fieldsNode) {
-        // Hide everything except the status bar, title and type
+        // Hide everything except the status bar, type and global fields
         for (let i = 0; i < fieldsNode.length; i++) {
           let field = fieldsNode[i].dataset.field
           if (field !== 'status' &&
           field !== 'type' &&
-          field.key.split("_")[1] !== 'global' )
+          field.split("_")[1] !== 'global' )
           fieldsNode[i].style.display = 'none'
         }
       },


### PR DESCRIPTION
Check for the `global` type, so it's possible to have fields that are visible with any `type`.

It wouldn't need to be added to the `type` value set.

These global fields would need to be named with the same convention for the current implementation:

| collection | type      | field   |
| --- | --- | --- |
| block | global | title |

> BREAKING CHANGE: for the looks of the current implementation, it seems that any field named `title` should be interpreted as an *always visible* field (similar to this global concept). In the current PR, I removed `title` from the hiding conditions, but I could add it again. The idea was to make the extension more generic.