### PR TITLE
refactor: improve the global fields feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,24 +25,15 @@ Once you have setup your `type` field, you need to name your fields like the abo
 | block      | image     | picture |
 | block      | image     | alt     |
 
-> Also you can include `global` fields, that will be visible for any type
-
-| collection | type      | field   |
-|------------|-----------|---------|
-| block      | global	 | title   |
-| block      | global	 | slug	   |
-
 So the fields in the database should be like
 ```
 block_editorial_text
 block_editorial_intro
 block_image_picture
 block_image_alt
-block_global_title
-block_global_slug
 ```
 
-With that config, if you select the type `editorial` in the dropdown, only the `title`, `slug`, `text` and `intro` fields will appear on the screen.
+With that config, if you select the type `editorial` in the dropdown, only the `text` and `intro` fields will appear on the screen (and any other field that doesn't start with the collection name).
 
 ### Import conditional-fields into the collection
 Once you have setup your fields, you can then just add the `conditional-fields` field so the javascript can do his job on the administration page.

--- a/src/input.vue
+++ b/src/input.vue
@@ -10,13 +10,10 @@
     mounted() {
       // Fetch block options
       const { values } = this._props
+      
       const fieldsNode = document.querySelectorAll('[data-field]');
-      const conditionalInterface = document.querySelector('[data-field="conditional_interface"]');
       const typeField = document.querySelector('[data-field=type]');
       const options = this.getOptions();
-
-      // hide this custom interface
-      if (conditionalInterface) conditionalInterface.style.display = 'none'
 
       // hide all fields until the user choose a type
       this.hideAll(fieldsNode)
@@ -47,13 +44,14 @@
         }
       },
       hideAll(fieldsNode) {
-        // Hide everything except the status bar, type and global fields
+        const collectionName = this.getCollectionName(this.$parent.collection);
+
+        // Hide all the fields that start with the collection name + the conditional_interface
         for (let i = 0; i < fieldsNode.length; i++) {
           let field = fieldsNode[i].dataset.field
-          if (field !== 'status' &&
-          field !== 'type' &&
-          field.split("_")[1] !== 'global' )
-          fieldsNode[i].style.display = 'none'
+
+          if (field.startsWith(`${collectionName}_`) || field === 'conditional_interface')
+            fieldsNode[i].style.display = 'none'
         }
       },
       getOptions() {
@@ -65,14 +63,14 @@
         let options = [];
 
         Object.keys(fields).forEach(( key, index ) => {
-            if (key.startsWith(`${collectionName}_`) && key !== "conditional_interface") {
-              const splitKeys = key.split("_");
-              const type = splitKeys[1];
+          if (key.startsWith(`${collectionName}_`) && key !== "conditional_interface") {
+            const splitKeys = key.split("_");
+            const type = splitKeys[1];
 
-              if (!options[type]) options[type] = []
+            if (!options[type]) options[type] = []
 
-              options[type].push(key)
-            }
+            options[type].push(key)
+          }
         });
 
         return options;
@@ -82,9 +80,7 @@
           for (let i = 0; i < fieldsNode.length; i++) {
             let field = document.querySelector('[data-field=' + fieldsNode[i] + ']');
 
-            if (field) {
-              field.style.display = 'block'
-            }
+            if (field) field.style.display = 'block';
           }
         }
       },


### PR DESCRIPTION
So I thought it would be better for any field that doesn't follow the *conditional naming convention* to be displayed (global field), instead of having to name them `collection_global_field`. It'll make for a much cleaner data-model and should be less error prone.

Also this way, we'll keep retro-compatibility with the initial implementation 😄 